### PR TITLE
Add option to await browser tasks via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ uv run server --port 8000
 ```
 OPENAI_API_KEY=[your api key]
 CHROME_PATH=[only change this if you have a custom chrome build]
+PATIENT=false # Set to true if you want api calls to wait for tasks to complete (default is false)
 ```
 
 - we will be adding support for other LLM providers to power browser-use

--- a/server/server.py
+++ b/server/server.py
@@ -462,7 +462,6 @@ def create_mcp_server(
                 ]
 
             # Get the current task data
-            await _sleepy()
             task_data = task_store[task_id].copy()
 
             # If task is still running, add simple guidance

--- a/server/server.py
+++ b/server/server.py
@@ -408,7 +408,7 @@ def create_mcp_server(
             }
 
             # Start task in background
-            asyncio.create_task(
+            _task = asyncio.create_task(
                 run_browser_task_async(
                     task_id=task_id,
                     url=arguments["url"],
@@ -420,9 +420,11 @@ def create_mcp_server(
                 )
             )
 
+            # If PATIENT is set, wait for the task to complete
+            if os.environ.get("PATIENT", None) == "true":
+                await _task
+
             # Return task ID immediately with explicit sleep instruction
-            if _sleep_interval := int(os.environ.get("SLEEP_INTERVAL", 0)):
-                await asyncio.sleep(_sleep_interval)
             return [
                 types.TextContent(
                     type="text",
@@ -460,6 +462,7 @@ def create_mcp_server(
                 ]
 
             # Get the current task data
+            await _sleepy()
             task_data = task_store[task_id].copy()
 
             # If task is still running, add simple guidance

--- a/server/server.py
+++ b/server/server.py
@@ -421,7 +421,7 @@ def create_mcp_server(
             )
 
             # Return task ID immediately with explicit sleep instruction
-            if (_sleep_interval := int(os.environ.get("SLEEP_INTERVAL", 0))):
+            if _sleep_interval := int(os.environ.get("SLEEP_INTERVAL", 0)):
                 await asyncio.sleep(_sleep_interval)
             return [
                 types.TextContent(

--- a/server/server.py
+++ b/server/server.py
@@ -421,6 +421,8 @@ def create_mcp_server(
             )
 
             # Return task ID immediately with explicit sleep instruction
+            if (_sleep_interval := int(os.environ.get("SLEEP_INTERVAL", 0))):
+                await asyncio.sleep(_sleep_interval)
             return [
                 types.TextContent(
                     type="text",


### PR DESCRIPTION
First off, after trying a bunch of similar tools, this is the best I've found for my use case so far. Great job! 🎉

This PR adds an environment variable option to wait for API calls to complete before returning the task. There's probably a better way of doing this.

My motivation for doing this is that I'm using this MCP server in an n8n workflow, however in n8n there's not a way to insert a delay between tool calls when using the agent node (AFAIK).